### PR TITLE
Fix roadmap location to avoid notion login page and additional redirect

### DIFF
--- a/app/routes/roadmap/index.tsx
+++ b/app/routes/roadmap/index.tsx
@@ -3,7 +3,7 @@ import { LoaderFunction, redirect } from "remix";
 export const loader: LoaderFunction = async () => {
   // Remove this loader code to remove the redirect
   return redirect(
-    "https://www.notion.so/metricsdao/MetricsDAO-Roadmap-09ce7d1f23a741b38f63587be59574a6",
+    "https://metricsdao.notion.site/metricsdao/MetricsDAO-Roadmap-09ce7d1f23a741b38f63587be59574a6",
     302
   );
 };


### PR DESCRIPTION
The current roadmap link (https://www.notion.so/metricsdao/MetricsDAO-Roadmap-09ce7d1f23a741b38f63587be59574a6) forces notion users to login or click on final url as this is not meant for public sharing.  So replacing it with public url that does not additional redirection.