### PR TITLE
added docs button in header and footer

### DIFF
--- a/app/components/app-footer.tsx
+++ b/app/components/app-footer.tsx
@@ -31,6 +31,17 @@ export default function AppFooter() {
                 <span className="ms-2 text-uppercase">mirror</span>
               </div>
             </li>
+            <li className="ms-3 mb-lg-3">
+              <div className="d-flex flex-column flex-lg-row justify-content-start align-items-center">
+                <a
+                  className="btn btn-outline-dark"
+                  href="https://docs.metricsdao.xyz/"
+                >
+                  <i className="bi bi-book-half"></i>
+                </a>
+                <span className="ms-2 text-uppercase">docs</span>
+              </div>
+            </li>
           </ul>
         </div>
       </div>

--- a/app/components/landing-header.tsx
+++ b/app/components/landing-header.tsx
@@ -54,6 +54,14 @@ const DesktopHeader = () => {
                 href="https://metricsdao.mirror.xyz/"
               ></a>
             </li>
+            <li className="ms-2 social-network">
+              <a
+                className="btn btn-outline-dark"
+                href="https://docs.metricsdao.xyz/"
+              >
+                <i className="bi bi-book-half"></i>
+              </a>
+            </li>
           </ul>
         </header>
         <section className="intro text-center">


### PR DESCRIPTION
# Description

Adds the documentation button in both the header and the footer. Solves issue #8.


# Tests 

- [x] Provide evidence that the changes are applied.

![image](https://user-images.githubusercontent.com/99073366/168861357-b8f017fb-a84d-4679-bbb7-46269907006c.png)
![image](https://user-images.githubusercontent.com/99073366/168861496-263700e0-2ecc-4fa4-a570-7e3dedd53102.png)
