### PR TITLE
Add Docs link in header and footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 /public/build
 /api/index.js
 api/index.js
+
+.idea/

--- a/app/components/app-footer.tsx
+++ b/app/components/app-footer.tsx
@@ -11,7 +11,7 @@ export default function AppFooter() {
             </Link>
           </div>
           <ul className="nav col-auto justify-content-end list-unstyled d-flex flex-row flex-lg-column social-network">
-            <li className="ms-3 mb-lg-3">
+            <li className="mb-lg-3">
               <div className="d-flex flex-column flex-lg-row justify-content-start align-items-center">
                 <a
                   className="btn btn-outline-dark"
@@ -19,17 +19,26 @@ export default function AppFooter() {
                 >
                   <i className="bi bi-twitter"></i>
                 </a>
-                <span className="ms-2 text-uppercase">twitter</span>
+                <span className="ms-md-2 text-uppercase">twitter</span>
               </div>
             </li>
-            <li className="ms-3 mb-lg-3">
+            <li className="mb-lg-3">
               <div className="d-flex flex-column flex-lg-row justify-content-start align-items-center">
                 <a
                   className="btn btn-outline-dark bi-mirror"
                   href="https://metricsdao.mirror.xyz/"
                 ></a>
-                <span className="ms-2 text-uppercase">mirror</span>
+                <span className="ms-md-2 text-uppercase">mirror</span>
               </div>
+            </li>
+            <li className="mb-lg-3">
+              <a href="https://docs.metricsdao.xyz/"
+                 className="d-flex flex-column flex-lg-row justify-content-start align-items-center text-black text-decoration-none">
+                <span className="btn btn-outline-dark">
+                  <i className="bi bi-file-earmark-text-fill"></i>
+                </span>
+                <span className="ms-md-2 text-uppercase">docs</span>
+              </a>
             </li>
           </ul>
         </div>

--- a/app/components/landing-header.tsx
+++ b/app/components/landing-header.tsx
@@ -54,6 +54,14 @@ const DesktopHeader = () => {
                 href="https://metricsdao.mirror.xyz/"
               ></a>
             </li>
+            <li className="ms-2 social-network">
+              <a
+                  className="btn btn-outline-dark"
+                  href="https://docs.metricsdao.xyz/"
+              >
+                <i className="bi bi-file-earmark-text-fill"></i>
+              </a>
+            </li>
           </ul>
         </header>
         <section className="intro text-center">
@@ -157,20 +165,20 @@ const MobileHeader = () => {
           </section>
 
           <header className="pb-5 d-flex flex-wrap justify-content-between align-items-center">
-            <ul className="nav col-12 justify-content-end list-unstyled d-flex align-items-center justify-content-center">
+            <ul className="nav col-12 list-unstyled d-flex align-items-center justify-content-between">
               <Link
                 to="/roadmap"
-                className="btn btn-outline-dark rounded-pill px-3 me-2"
+                className="btn btn-outline-dark rounded-pill px-3"
               >
                 ROADMAP
               </Link>
               <Link
                 to="#contactus"
-                className="btn btn-outline-dark rounded-pill px-3 me-2 text-uppercase"
+                className="btn btn-outline-dark rounded-pill px-3 text-uppercase"
               >
                 Partner with Us
               </Link>
-              <li className="ms-0 social-network">
+              <li className="social-network">
                 <a
                   className="btn btn-outline-dark"
                   href="https://twitter.com/MetricsDAO"
@@ -178,11 +186,19 @@ const MobileHeader = () => {
                   <i className="bi bi-twitter"></i>
                 </a>
               </li>
-              <li className="ms-2 social-network">
+              <li className="social-network">
                 <a
                   className="btn btn-outline-dark bi-mirror"
                   href="https://metricsdao.mirror.xyz/"
                 ></a>
+              </li>
+              <li className="social-network">
+                <a
+                    className="btn btn-outline-dark"
+                    href="https://docs.metricsdao.xyz/"
+                >
+                  <i className="bi bi-file-earmark-text-fill"></i>
+                </a>
               </li>
             </ul>
           </header>

--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -689,6 +689,11 @@ strong {
     padding: 0 50px;
   }
 
+  .site-footer .nav {
+    flex: 1;
+    justify-content: space-between!important;
+  }
+
   .footer-brand img {
     max-width: 80%;
   }


### PR DESCRIPTION
- Docs link added in Header and Footer (Issue [#8](https://github.com/MetricsDAO/xyz/issues/8))
- Fixed alignments in Header and Footer (Mobile View)

![Screenshot 2022-05-18 at 1 22 06 PM](https://user-images.githubusercontent.com/105657030/168987389-1425a5aa-257a-4fc2-8ef3-01b99483443f.png)
![Screenshot 2022-05-18 at 1 24 44 PM](https://user-images.githubusercontent.com/105657030/168987418-76581b11-1c11-45c1-bc93-5a0da78ef70c.png)
![Screenshot 2022-05-18 at 1 23 09 PM](https://user-images.githubusercontent.com/105657030/168987408-55799591-a1d5-43f7-957a-e11904780f23.png)
![Screenshot 2022-05-18 at 1 23 42 PM](https://user-images.githubusercontent.com/105657030/168987412-3cb5a9d9-5418-4551-9ecb-4f72166b1198.png)
