### PR TITLE
filter out contract on backend instead of frontend to reduce js payload

### DIFF
--- a/app/components/ContractContextWrapper.tsx
+++ b/app/components/ContractContextWrapper.tsx
@@ -1,32 +1,30 @@
 import { createContext } from "react";
 import type { ReactElement } from "react";
-import type { ContractContextEntity } from "~/utils/types";
+import type { ContractContextEntity, ContractEntity } from "~/utils/types";
 
 // TODO: Improve the typings and init context
 export const ContractContext = createContext<ContractContextEntity>({
-    contracts: {
-        bountyQuestion: {address: "", abi: ""},
-        questionAPI: {address: "", abi: ""},
-        xmetric: {address: "", abi: ""},
-        costController: {address: "", abi: ""},
-        vault: {address: "", abi: ""},
-        questionStateController: {address: "", abi: ""}
-    }, 
-    network: ""
+  contracts: {
+    bountyQuestion: { address: "", abi: [] },
+    questionAPI: { address: "", abi: [] },
+    xmetric: { address: "", abi: [] },
+    costController: { address: "", abi: [] },
+    vault: { address: "", abi: [] },
+    questionStateController: { address: "", abi: [] },
+  },
+  network: "",
 });
 
-export default function ContractContextWrapper({ 
-    children,
-    network,
-    contracts
+export default function ContractContextWrapper({
+  children,
+  network,
+  contracts,
 }: {
-    children: ReactElement
-    network: string
-    contracts?: any
+  children: ReactElement;
+  network: string;
+  contracts: Record<string, ContractEntity>;
 }) {
-    return (
-        <ContractContext.Provider value={{contracts: contracts, network: network}}>
-            { children }
-        </ContractContext.Provider>
-    )
+  return (
+    <ContractContext.Provider value={{ contracts: contracts, network: network }}>{children}</ContractContext.Provider>
+  );
 }

--- a/app/routes/all-questions/index.tsx
+++ b/app/routes/all-questions/index.tsx
@@ -7,7 +7,22 @@ import { getContracts } from "~/services/contracts.server";
 
 export async function loader() {
   const network = process.env.NETWORK || "localhost";
-  const { bountyQuestionJson, questionAPIJson, questionStateController } = getContracts({network: network});
+  const contractData = getContracts({ network: network });
+
+  const bountyQuestionJson = {
+    abi: contractData.bountyQuestionJson.abi,
+    address: contractData.bountyQuestionJson.address,
+  };
+
+  const questionAPIJson = {
+    abi: contractData.questionAPIJson.abi,
+    address: contractData.questionAPIJson.address,
+  };
+
+  const questionStateController = {
+    abi: contractData.questionStateController.abi,
+    address: contractData.questionStateController.address,
+  };
 
   return {
     bountyQuestionJson,
@@ -17,15 +32,14 @@ export async function loader() {
   };
 }
 
-
 export default function Index() {
   const { network, bountyQuestionJson, questionAPIJson, questionStateController } = useLoaderData();
 
   const contracts = {
     bountyQuestion: bountyQuestionJson,
     questionAPI: questionAPIJson,
-    questionStateController: questionStateController
-  }
+    questionStateController: questionStateController,
+  };
 
   return (
     <WalletProvider network={network}>

--- a/app/routes/question-generation/index.tsx
+++ b/app/routes/question-generation/index.tsx
@@ -13,7 +13,27 @@ import ContractContextWrapper from "~/components/ContractContextWrapper";
 
 export async function loader() {
   const network = process.env.NETWORK || "localhost";
-  const { xMetricJson, questionAPIJson, vaultJson, costController } = getContracts({network: network});
+  const constractData = getContracts({ network: network });
+
+  const xMetricJson = {
+    abi: constractData.xMetricJson.abi,
+    address: constractData.xMetricJson.address,
+  };
+
+  const questionAPIJson = {
+    abi: constractData.questionAPIJson.abi,
+    address: constractData.questionAPIJson.address,
+  };
+
+  const vaultJson = {
+    abi: constractData.vaultJson.abi,
+    address: constractData.vaultJson.address,
+  };
+
+  const costController = {
+    abi: constractData.costController.abi,
+    address: constractData.costController.address,
+  };
 
   return {
     xMetricJson,
@@ -27,32 +47,12 @@ export async function loader() {
 export default function Index() {
   const { xMetricJson, questionAPIJson, vaultJson, costController, network } = useLoaderData();
 
-  const xMETRICAbiAndAddress = {
-    abi: xMetricJson.abi,
-    address: xMetricJson.address,
-  };
-
-  const questionAPIAbiAndAddress = {
-    abi: questionAPIJson.abi,
-    address: questionAPIJson.address,
-  };
-
-  const vaultAbiandAddress = {
-    abi: vaultJson.abi,
-    address: vaultJson.address,
-  };
-
-  const costControllerAbiandAddress = {
-    abi: costController.abi,
-    address: costController.address,
-  };
-
   const contracts = {
-   xmetric: xMETRICAbiAndAddress,
-   questionAPI: questionAPIAbiAndAddress,
-   vault: vaultAbiandAddress,
-   costController: costControllerAbiandAddress
-  }
+    xmetric: xMetricJson,
+    questionAPI: questionAPIJson,
+    vault: vaultJson,
+    costController: costController,
+  };
 
   /* ELEMENT CLONED IN WRAPPER */
   function ClaimBody({
@@ -76,7 +76,7 @@ export default function Index() {
         <h1 className="tw-text-5xl tw-mx-auto tw-pt-10 tw-pb-5 tw-font-bold">Question Generation</h1>
         {address ? (
           <ContractContextWrapper contracts={contracts} network={network}>
-            <NetworkRender network={network} chainName={chainName} chainId={chainId} switchNetwork={switchNetwork}>
+            <NetworkRender network={network} chainName={chainName} switchNetwork={switchNetwork}>
               <CreateQuestionContainer address={address} />
             </NetworkRender>
           </ContractContextWrapper>

--- a/app/services/contracts.server.ts
+++ b/app/services/contracts.server.ts
@@ -1,44 +1,41 @@
-
 export function getContracts({ network }: { network: string }) {
-    let xMetricJson;
-    let questionAPIJson;
-    let questionStateController;
-    let bountyQuestionJson;
-    let costController;
-    let vaultJson;
+  let xMetricJson;
+  let questionAPIJson;
+  let questionStateController;
+  let bountyQuestionJson;
+  let costController;
+  let vaultJson;
 
+  if (network === "ropsten") {
+    xMetricJson = require(`core-evm-contracts/deployments/ropsten/Xmetric.json`);
+    questionAPIJson = require(`core-evm-contracts/deployments/ropsten/QuestionAPI.json`);
+    questionStateController = require(`core-evm-contracts/deployments/ropsten/QuestionStateController.json`);
+    bountyQuestionJson = require(`core-evm-contracts/deployments/ropsten/BountyQuestion.json`);
+    costController = require(`core-evm-contracts/deployments/ropsten/ActionCostController.json`);
+    vaultJson = require(`core-evm-contracts/deployments/ropsten/Vault.json`);
+  } else if (network === "polygon") {
+    xMetricJson = require(`core-evm-contracts/deployments/polygon/Xmetric.json`);
+    questionAPIJson = require(`core-evm-contracts/deployments/polygon/QuestionAPI.json`);
+    questionStateController = require(`core-evm-contracts/deployments/polygon/QuestionStateController.json`);
+    bountyQuestionJson = require(`core-evm-contracts/deployments/polygon/BountyQuestion.json`);
+    costController = require(`core-evm-contracts/deployments/polygon/ActionCostController.json`);
+    vaultJson = require(`core-evm-contracts/deployments/polygon/Vault.json`);
+  } else {
+    //localhost
+    xMetricJson = require(`core-evm-contracts/deployments/localhost/Xmetric.json`);
+    questionAPIJson = require(`core-evm-contracts/deployments/localhost/QuestionAPI.json`);
+    questionStateController = require(`core-evm-contracts/deployments/localhost/QuestionStateController.json`);
+    bountyQuestionJson = require(`core-evm-contracts/deployments/localhost/BountyQuestion.json`);
+    costController = require(`core-evm-contracts/deployments/localhost/ActionCostController.json`);
+    vaultJson = require(`core-evm-contracts/deployments/localhost/Vault.json`);
+  }
 
-    if (network === "ropsten") {
-        xMetricJson = require(`core-evm-contracts/deployments/ropsten/Xmetric.json`);
-        questionAPIJson = require(`core-evm-contracts/deployments/ropsten/QuestionAPI.json`);
-        questionStateController = require(`core-evm-contracts/deployments/ropsten/QuestionStateController.json`);
-        bountyQuestionJson = require(`core-evm-contracts/deployments/ropsten/BountyQuestion.json`);
-        costController = require(`core-evm-contracts/deployments/ropsten/ActionCostController.json`);
-        vaultJson = require(`core-evm-contracts/deployments/ropsten/Vault.json`);
-    } else if (network === "polygon") {
-        xMetricJson = require(`core-evm-contracts/deployments/polygon/Xmetric.json`);
-        questionAPIJson = require(`core-evm-contracts/deployments/polygon/QuestionAPI.json`);
-        questionStateController = require(`core-evm-contracts/deployments/polygon/QuestionStateController.json`);
-        bountyQuestionJson = require(`core-evm-contracts/deployments/polygon/BountyQuestion.json`);
-        costController = require(`core-evm-contracts/deployments/polygon/ActionCostController.json`);
-        vaultJson = require(`core-evm-contracts/deployments/polygon/Vault.json`);
-    } else { //localhost
-        xMetricJson = require(`core-evm-contracts/deployments/localhost/Xmetric.json`);
-        questionAPIJson = require(`core-evm-contracts/deployments/localhost/QuestionAPI.json`);
-        questionStateController = require(`core-evm-contracts/deployments/localhost/QuestionStateController.json`);
-        bountyQuestionJson = require(`core-evm-contracts/deployments/localhost/BountyQuestion.json`);
-        costController = require(`core-evm-contracts/deployments/localhost/ActionCostController.json`);
-        vaultJson = require(`core-evm-contracts/deployments/localhost/Vault.json`);
-    }
-
-    console.log("Getting abis")
-
-    return {
-        xMetricJson,
-        questionAPIJson,
-        questionStateController,
-        bountyQuestionJson,
-        costController,
-        vaultJson
-    }
+  return {
+    xMetricJson,
+    questionAPIJson,
+    questionStateController,
+    bountyQuestionJson,
+    costController,
+    vaultJson,
+  };
 }

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -51,7 +51,7 @@ export interface FCProps {
 }
 
 export interface ContractEntity {
-  abi: string;
+  abi: Record<string, string>[];
   address: string;
 }
 
@@ -59,4 +59,3 @@ export interface ContractContextEntity {
   contracts: Record<string, ContractEntity>;
   network: string;
 }
-


### PR DESCRIPTION
This was an existing bug implemented by me - We should be filtering out parts of the contract json we are not using on the backend so the front end only gets what is needed
