### PR TITLE
Fix: Reseeding db (without yarn reset) won't work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ app/styles/app.css
 .idea/
 
 yarn-error.log
+
+.vs

--- a/app/services/labor-market.server.ts
+++ b/app/services/labor-market.server.ts
@@ -70,27 +70,33 @@ export const upsertLaborMarket = async (laborMarket: LaborMarket) => {
   const { address, projectIds, tokenSymbols, ...data } = laborMarket;
   const newLaborMarket = await prisma.laborMarket.upsert({
     where: { address },
-    update: data,
-    create: {
-      address,
-      title: data.title,
-      description: data.description,
-      type: data.type,
-      submitRepMin: data.submitRepMin,
-      submitRepMax: data.submitRepMax,
-      rewardCurveAddress: data.rewardCurveAddress,
-      reviewBadgerAddress: data.reviewBadgerAddress,
-      reviewBadgerTokenId: data.reviewBadgerTokenId,
-      launchAccess: data.launch.access,
-      launchBadgerAddress: data.launch.access === "delegates" ? data.launch.badgerAddress : undefined,
-      launchBadgerTokenId: data.launch.access === "delegates" ? data.launch.badgerTokenId : undefined,
-      sponsorAddress: data.sponsorAddress,
-      projects: { connect: projectIds.map((id) => ({ id })) },
-      tokens: { connect: tokenSymbols.map((symbol) => ({ symbol })) },
-    },
+    update: mapToLaborMarketTableFormat(laborMarket),
+    create: mapToLaborMarketTableFormat(laborMarket),
   });
   return newLaborMarket;
 };
+
+const mapToLaborMarketTableFormat = (laborMarket: LaborMarket) => {
+  const { address, projectIds, tokenSymbols, ...data } = laborMarket;
+
+  return {
+    address,
+    title: data.title,
+    description: data.description,
+    type: data.type,
+    submitRepMin: data.submitRepMin,
+    submitRepMax: data.submitRepMax,
+    rewardCurveAddress: data.rewardCurveAddress,
+    reviewBadgerAddress: data.reviewBadgerAddress,
+    reviewBadgerTokenId: data.reviewBadgerTokenId,
+    launchAccess: data.launch.access,
+    launchBadgerAddress: data.launch.access === "delegates" ? data.launch.badgerAddress : undefined,
+    launchBadgerTokenId: data.launch.access === "delegates" ? data.launch.badgerTokenId : undefined,
+    sponsorAddress: data.sponsorAddress,
+    projects: { connect: projectIds.map((id) => ({ id })) },
+    tokens: { connect: tokenSymbols.map((symbol) => ({ symbol })) },
+  };
+}
 
 /**
  * Counts the number of LaborMarkets that match a given LaborMarketSearch.

--- a/app/services/labor-market.server.ts
+++ b/app/services/labor-market.server.ts
@@ -67,7 +67,7 @@ export const prepareLaborMarket = async (newLaborMarket: LaborMarketNew) => {
  * @param {LaborMarket} laborMarket - The labor market to create.
  */
 export const upsertLaborMarket = async (laborMarket: LaborMarket) => {
-  const { address, projectIds, tokenSymbols, ...data } = laborMarket;
+  const { address } = laborMarket;
   const newLaborMarket = await prisma.laborMarket.upsert({
     where: { address },
     update: mapToLaborMarketTableFormat(laborMarket),
@@ -78,7 +78,6 @@ export const upsertLaborMarket = async (laborMarket: LaborMarket) => {
 
 const mapToLaborMarketTableFormat = (laborMarket: LaborMarket) => {
   const { address, projectIds, tokenSymbols, ...data } = laborMarket;
-
   return {
     address,
     title: data.title,
@@ -96,7 +95,7 @@ const mapToLaborMarketTableFormat = (laborMarket: LaborMarket) => {
     projects: { connect: projectIds.map((id) => ({ id })) },
     tokens: { connect: tokenSymbols.map((symbol) => ({ symbol })) },
   };
-}
+};
 
 /**
  * Counts the number of LaborMarkets that match a given LaborMarketSearch.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,7 +19,7 @@ async function main() {
       { slug: "near", name: "Near" },
       { slug: "flow", name: "Flow" },
       { slug: "ethereum", name: "Ethereum" },
-    ], 
+    ],
     skipDuplicates: true,
   });
 
@@ -33,7 +33,7 @@ async function main() {
       { symbol: "NEAR", name: "Near" },
       { symbol: "FLOW", name: "Flow" },
       { symbol: "AVAX", name: "Avalanche" },
-    ], 
+    ],
     skipDuplicates: true,
   });
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,7 +19,8 @@ async function main() {
       { slug: "near", name: "Near" },
       { slug: "flow", name: "Flow" },
       { slug: "ethereum", name: "Ethereum" },
-    ], skipDuplicates: true
+    ], 
+    skipDuplicates: true,
   });
 
   await prisma.token.createMany({
@@ -32,7 +33,8 @@ async function main() {
       { symbol: "NEAR", name: "Near" },
       { symbol: "FLOW", name: "Flow" },
       { symbol: "AVAX", name: "Avalanche" },
-    ], skipDuplicates: true
+    ], 
+    skipDuplicates: true,
   });
 
   async function seedLaborMarkets() {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,7 +19,7 @@ async function main() {
       { slug: "near", name: "Near" },
       { slug: "flow", name: "Flow" },
       { slug: "ethereum", name: "Ethereum" },
-    ],
+    ], skipDuplicates: true
   });
 
   await prisma.token.createMany({
@@ -32,7 +32,7 @@ async function main() {
       { symbol: "NEAR", name: "Near" },
       { symbol: "FLOW", name: "Flow" },
       { symbol: "AVAX", name: "Avalanche" },
-    ],
+    ], skipDuplicates: true
   });
 
   async function seedLaborMarkets() {


### PR DESCRIPTION
- When seeding the db more than once will cause some error messages
- Those are not really relevant, `yarn reset` does work for reseeding
- Those are daunting for someone trying to run this locally, following the instructions in the readme will lead you to those

- Also added `.vs` folder to gitignore 