### PR TITLE
Redirect flow

### DIFF
--- a/app/features/web3-transaction-toasts.tsx
+++ b/app/features/web3-transaction-toasts.tsx
@@ -1,4 +1,5 @@
 import { XMarkIcon } from "@heroicons/react/20/solid";
+import { duration } from "dayjs";
 import toast from "react-hot-toast";
 
 export const defaultNotifyTransactionActions = {
@@ -40,6 +41,23 @@ export const defaultNotifyTransactionActions = {
     toast.dismiss("waiting-on-transaction");
     toast.error("Transaction failed");
   },
+};
+
+export const notifyTransactionIndexing = (transactionHash?: string) => {
+  toast.loading(
+    (t) => {
+      return (
+        <>
+          <div> Indexing... It might take a moment to appear </div>
+          <PolygonscanLink transactionHash={transactionHash} />
+          <button onClick={() => toast.dismiss(t.id)} className="flex items-center px-3">
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </>
+      );
+    },
+    { id: "waiting-on-indexing", duration: 10000 }
+  );
 };
 
 const PolygonscanLink = ({ transactionHash }: { transactionHash?: string }) => {

--- a/app/features/web3-transaction-toasts.tsx
+++ b/app/features/web3-transaction-toasts.tsx
@@ -33,6 +33,7 @@ export const defaultNotifyTransactionActions = {
         );
       },
       {
+        id: "transaction-success",
         duration: 15000,
       }
     );
@@ -56,7 +57,7 @@ export const notifyTransactionIndexing = (transactionHash?: string) => {
         </>
       );
     },
-    { id: "waiting-on-indexing", duration: 10000 }
+    { id: "waiting-on-indexing", duration: 15000 }
   );
 };
 

--- a/app/routes/app/$mType/m/$laborMarketAddress.s/$submissionId.tsx
+++ b/app/routes/app/$mType/m/$laborMarketAddress.s/$submissionId.tsx
@@ -1,5 +1,5 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { useParams, useSubmit } from "@remix-run/react";
+import { useNavigate, useParams, useSubmit } from "@remix-run/react";
 import { withZod } from "@remix-validated-form/with-zod";
 import type { SendTransactionResult } from "@wagmi/core";
 import { useMachine } from "@xstate/react";
@@ -42,6 +42,7 @@ import { findSubmission } from "~/services/submissions.server";
 import { SCORE_COLOR } from "~/utils/constants";
 import { fromNow } from "~/utils/date";
 import { createBlockchainTransactionStateMachine } from "~/utils/machine";
+import { $path } from "remix-routes";
 
 const paramsSchema = z.object({
   laborMarketAddress: z.string(),
@@ -190,6 +191,8 @@ function ReviewQuestionDrawerButton({
   const [selected, setSelected] = useState<number>(2);
   const [scoreSelectionOpen, setScoreSelectionOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const navigate = useNavigate();
+  const { mType } = useParams();
 
   const [state, send] = useMachine(reviewSubmissionMachine, {
     actions: {
@@ -201,6 +204,16 @@ function ReviewQuestionDrawerButton({
       },
       notifyTransactionFailure: () => {
         defaultNotifyTransactionActions.notifyTransactionFailure();
+      },
+      redirect: () => {
+        invariant(state.context.contractData, "Contract data is required");
+        navigate(
+          $path("/app/:mType/m/:laborMarketAddress/sr/:serviceRequestId", {
+            mType: mType,
+            laborMarketAddress: submission.laborMarketAddress,
+            serviceRequestId: submission.serviceRequestId,
+          })
+        );
       },
     },
   });

--- a/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.claim.tsx
+++ b/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.claim.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "@remix-run/react";
+import { Link, useNavigate, useParams } from "@remix-run/react";
 import type { DataFunctionArgs } from "@remix-run/server-runtime";
 import type { SendTransactionResult } from "@wagmi/core";
 import { useMachine } from "@xstate/react";
@@ -40,6 +40,7 @@ export default function ClaimToSubmit() {
   const { serviceRequest } = useTypedLoaderData<typeof loader>();
   const { mType } = useParams();
   invariant(mType, "marketplace type must be specified");
+  const navigate = useNavigate();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -53,6 +54,16 @@ export default function ClaimToSubmit() {
       },
       notifyTransactionFailure: () => {
         defaultNotifyTransactionActions.notifyTransactionFailure();
+      },
+      redirect: () => {
+        invariant(state.context.contractData, "Contract data is required");
+        navigate(
+          $path("/app/:mType/m/:laborMarketAddress/sr/:serviceRequestId", {
+            mType: mType,
+            laborMarketAddress: serviceRequest.laborMarketAddress,
+            serviceRequestId: serviceRequest.id,
+          })
+        );
       },
     },
   });

--- a/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.review.tsx
+++ b/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.review.tsx
@@ -21,7 +21,7 @@ import ConnectWalletWrapper from "~/features/connect-wallet-wrapper";
 import { REPUTATION_SIGNAL_STAKE } from "~/utils/constants";
 import { claimToReviewDeadline } from "~/utils/helpers";
 import { RPCError } from "~/features/rpc-error";
-import { Link, useParams } from "@remix-run/react";
+import { Link, useNavigate, useParams } from "@remix-run/react";
 import { $path } from "remix-routes";
 import invariant from "tiny-invariant";
 
@@ -44,6 +44,8 @@ export default function ClaimToReview() {
   const { serviceRequest } = useTypedLoaderData<typeof loader>();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const { mType } = useParams();
+  const navigate = useNavigate();
+
   invariant(mType, "marketplace type must be specified");
 
   const [state, send] = useMachine(claimToSubmitMachine, {
@@ -56,6 +58,15 @@ export default function ClaimToReview() {
       },
       notifyTransactionFailure: () => {
         defaultNotifyTransactionActions.notifyTransactionFailure();
+      },
+      redirect: () => {
+        navigate(
+          $path("/app/:mType/m/:laborMarketAddress/sr/:serviceRequestId", {
+            mType: mType,
+            laborMarketAddress: serviceRequest.laborMarketAddress,
+            serviceRequestId: serviceRequest.id,
+          })
+        );
       },
     },
   });

--- a/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.submit.tsx
+++ b/app/routes/app/$mType/m/$laborMarketAddress.sr/$serviceRequestId.submit.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "@remix-run/react";
+import { useNavigate, useParams } from "@remix-run/react";
 import type { ActionArgs } from "@remix-run/server-runtime";
 import { withZod } from "@remix-validated-form/with-zod";
 import { useMachine } from "@xstate/react";
@@ -45,6 +45,7 @@ export default function SubmitQuestion() {
   const actionData = useTypedActionData<ActionResponse>();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const { mType } = useParams();
+  const navigate = useNavigate();
   const [state, send] = useMachine(submissionMachine, {
     actions: {
       notifyTransactionWait: (context) => {
@@ -55,6 +56,16 @@ export default function SubmitQuestion() {
       },
       notifyTransactionFailure: () => {
         defaultNotifyTransactionActions.notifyTransactionFailure();
+      },
+      redirect: () => {
+        invariant(state.context.contractData, "Contract data is required");
+        navigate(
+          $path("/app/:mType/m/:laborMarketAddress/sr/:serviceRequestId", {
+            mType: mType,
+            laborMarketAddress: state.context.contractData.laborMarketAddress,
+            serviceRequestId: state.context.contractData.serviceRequestId,
+          })
+        );
       },
     },
   });
@@ -328,4 +339,10 @@ function Analyze({
       </div>
     </Container>
   );
+}
+function $path(
+  arg0: string,
+  arg1: { mType: string | undefined; laborMarketAddress: any; serviceRequestId: any }
+): import("react-router").To {
+  throw new Error("Function not implemented.");
 }

--- a/app/routes/app/$mType/m/$laborMarketAddress.sr/new.tsx
+++ b/app/routes/app/$mType/m/$laborMarketAddress.sr/new.tsx
@@ -3,7 +3,7 @@ import type { ActionArgs, DataFunctionArgs } from "@remix-run/server-runtime";
 import { withZod } from "@remix-validated-form/with-zod";
 import { useMachine } from "@xstate/react";
 import { useEffect, useState } from "react";
-import { redirect, typedjson, useTypedActionData, useTypedLoaderData } from "remix-typedjson";
+import { typedjson, useTypedActionData, useTypedLoaderData } from "remix-typedjson";
 import { badRequest, notFound } from "remix-utils";
 import type { ValidationErrorResponseData } from "remix-validated-form";
 import { ValidatedForm, validationError } from "remix-validated-form";

--- a/app/routes/app/rewards/index.tsx
+++ b/app/routes/app/rewards/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useSubmit } from "@remix-run/react";
+import { Link, useNavigate, useParams, useSubmit } from "@remix-run/react";
 import { useRef } from "react";
 import { Checkbox } from "~/components/checkbox";
 import { Pagination } from "~/components/pagination/pagination";
@@ -33,6 +33,7 @@ import { Label } from "~/components";
 import { listTokens } from "~/services/tokens.server";
 import type { Token } from "@prisma/client";
 import { getParamsOrFail } from "remix-params-helper";
+import { $path } from "remix-routes";
 
 const validator = withZod(SubmissionSearchSchema);
 
@@ -172,6 +173,8 @@ const machine = createBlockchainTransactionStateMachine<ClaimRewardContractData>
 function ClaimButton() {
   const [confirmedModalOpen, setConfirmedModalOpen] = useState(false);
   const [successModalOpen, setSuccessModalOpen] = useState(false);
+  const { mType } = useParams();
+  const navigate = useNavigate();
 
   const [state, send] = useMachine(
     machine.withContext({
@@ -185,6 +188,9 @@ function ClaimButton() {
     {
       actions: {
         ...defaultNotifyTransactionActions,
+        redirect: () => {
+          navigate($path("/app/rewards"));
+        },
       },
     }
   );

--- a/app/utils/fetch.ts
+++ b/app/utils/fetch.ts
@@ -7,7 +7,7 @@ export function createLaborMarket(data: LaborMarket) {
   });
 }
 
-export function createServiceRequest(data: ServiceRequestIndexer) {
+export function openNewServiceRequest(data: ServiceRequestIndexer) {
   fetch("/api/indexer/create-service-request", {
     method: "POST",
     body: JSON.stringify(data),

--- a/app/utils/machine.ts
+++ b/app/utils/machine.ts
@@ -122,7 +122,7 @@ export const createBlockchainTransactionStateMachine = <T>() => {
               },
             },
             success: {
-              entry: ["notifyTransactionSuccess", "devAutoIndex"],
+              entry: ["notifyTransactionSuccess", "devAutoIndex", "redirect"],
             },
             failure: {
               entry: ["notifyTransactionFailure"],
@@ -161,6 +161,7 @@ export const createBlockchainTransactionStateMachine = <T>() => {
         notifyTransactionSuccess: () => {},
         notifyTransactionFailure: () => {},
         devAutoIndex: () => {},
+        redirect: () => {},
       },
     }
   );

--- a/app/utils/machine.typegen.ts
+++ b/app/utils/machine.typegen.ts
@@ -32,6 +32,7 @@ export interface Typegen0 {
   };
   eventsCausingActions: {
     devAutoIndex: "done.invoke.wait-for-transaction";
+    redirect: "done.invoke.wait-for-transaction";
     notifyTransactionFailure: "error.platform.wait-for-transaction";
     notifyTransactionSuccess: "done.invoke.wait-for-transaction";
     notifyTransactionWait: "SUBMIT_TRANSACTION";


### PR DESCRIPTION
This is not yet necessarily the ideal solution. Currently we don't pull contractIds on writes which prevents us from rerouting to the correct labor market or service request etc., but Chance says we should be able to get this data. @bcinman and I also discussed trying to pull data from Wagmi first and using the indexer for mostly just discovery and filter views. 