### PR TITLE
fix: tx modal step for async log parsing

### DIFF
--- a/app/components/tx-modal/tx-modal.tsx
+++ b/app/components/tx-modal/tx-modal.tsx
@@ -7,12 +7,17 @@ type Props = {
   transactor: Transactor;
   title?: string;
   confirmationMessage?: React.ReactNode;
+  redirectStep?: boolean;
   variant?: "primary" | "danger";
 };
 
-export function TxModal({ transactor, title, confirmationMessage, variant = "primary" }: Props) {
+export function TxModal({ transactor, title, confirmationMessage, redirectStep, variant = "primary" }: Props) {
+  const isRedirecting = transactor.state === "success" && redirectStep;
   return (
-    <Modal isOpen={transactor.state !== "idle" && transactor.state !== "success"} onClose={transactor.cancel}>
+    <Modal
+      isOpen={isRedirecting || (transactor.state !== "idle" && transactor.state !== "success")}
+      onClose={transactor.cancel}
+    >
       <div className="px-8 text-center mb-8 space-y-4">
         {variant === "danger" && <ExclamationTriangleIcon className="h-8 w-8 text-red-500 mx-auto my-4" />}
         <h1 className="text-base font-medium">{title ?? "Execute transaction"}</h1>
@@ -48,7 +53,7 @@ export function TxModal({ transactor, title, confirmationMessage, variant = "pri
           </div>
         ) : null}
 
-        {transactor.state === "redirect" ? (
+        {transactor.state === "success" ? (
           <div className="space-y-2">
             <p>Transaction confirmed! Redirecting...</p>
             <a

--- a/app/components/tx-modal/tx-modal.tsx
+++ b/app/components/tx-modal/tx-modal.tsx
@@ -47,6 +47,20 @@ export function TxModal({ transactor, title, confirmationMessage, variant = "pri
             </a>
           </div>
         ) : null}
+
+        {transactor.state === "redirect" ? (
+          <div className="space-y-2">
+            <p>Transaction confirmed! Redirecting...</p>
+            <a
+              className="text-blue-600"
+              target="_blank"
+              href={`https://polygonscan.com/tx/${transactor.receipt.transactionHash}`}
+              rel="noreferrer"
+            >
+              View on polygonscan
+            </a>
+          </div>
+        ) : null}
       </div>
 
       {transactor.state === "prepared" ? (

--- a/app/features/labor-market-creator/labor-market-creator.tsx
+++ b/app/features/labor-market-creator/labor-market-creator.tsx
@@ -25,7 +25,6 @@ export function LaborMarketCreator({
   const navigate = useNavigate();
 
   const transactor = useTransactor({
-    closeOnResolve: false,
     onSuccess: useCallback(
       (receipt) => {
         const iface = LaborMarketFactoryInterface__factory.createInterface();
@@ -64,6 +63,7 @@ export function LaborMarketCreator({
         transactor={transactor}
         title="Create Marketplace"
         confirmationMessage="Confirm that you would like to create a new marketplace."
+        redirectStep={true}
       />
       <OverviewForm defaultValues={defaultValues} onPrevious={onPrevious} onSubmit={onSubmit} />
     </>

--- a/app/features/labor-market-creator/labor-market-creator.tsx
+++ b/app/features/labor-market-creator/labor-market-creator.tsx
@@ -25,6 +25,7 @@ export function LaborMarketCreator({
   const navigate = useNavigate();
 
   const transactor = useTransactor({
+    closeOnResolve: false,
     onSuccess: useCallback(
       (receipt) => {
         const iface = LaborMarketFactoryInterface__factory.createInterface();

--- a/app/features/service-request-creator/service-request-creator.tsx
+++ b/app/features/service-request-creator/service-request-creator.tsx
@@ -65,7 +65,6 @@ export function ServiceRequestCreator({
   });
 
   const submitTransactor = useTransactor({
-    closeOnResolve: false,
     onSuccess: useCallback(
       (receipt) => {
         postNewEvent({
@@ -147,6 +146,7 @@ export function ServiceRequestCreator({
         transactor={submitTransactor}
         title="Launch Challenge"
         confirmationMessage={"Confirm that you would like to launch this challenge and transfer the funds"}
+        redirectStep={true}
       />
 
       <OverviewForm

--- a/app/features/service-request-creator/service-request-creator.tsx
+++ b/app/features/service-request-creator/service-request-creator.tsx
@@ -65,6 +65,7 @@ export function ServiceRequestCreator({
   });
 
   const submitTransactor = useTransactor({
+    closeOnResolve: false,
     onSuccess: useCallback(
       (receipt) => {
         postNewEvent({

--- a/app/features/submission-creator/submission-creator.tsx
+++ b/app/features/submission-creator/submission-creator.tsx
@@ -68,7 +68,7 @@ export default function SubmissionCreator({
 
   return (
     <>
-      <TxModal transactor={transactor} />
+      <TxModal transactor={transactor} redirectStep={true} />
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-10 py-5">
         <div className="space-y-10">
           <section className="space-y-3">

--- a/app/hooks/use-transactor.ts
+++ b/app/hooks/use-transactor.ts
@@ -26,18 +26,11 @@ type State =
   | { state: "writing" }
   | { state: "written"; result: WriteContractResult }
   | { state: "waiting"; transactionHash: `0x${string}` }
-  | { state: "redirect"; receipt: TransactionReceipt }
   | { state: "success"; receipt: TransactionReceipt };
 
 export type Transactor = ReturnType<typeof useTransactor>;
 
-export function useTransactor({
-  onSuccess,
-  closeOnResolve = true,
-}: {
-  onSuccess: (receipt: TransactionReceipt) => void;
-  closeOnResolve?: boolean;
-}) {
+export function useTransactor({ onSuccess }: { onSuccess: (receipt: TransactionReceipt) => void }) {
   const account = useAccount();
 
   const [state, setState] = useState<State>({ state: "idle" });
@@ -72,7 +65,7 @@ export function useTransactor({
     const result = await writeContract(state.prepared!);
     setState({ state: "waiting", transactionHash: result.hash });
     const receipt = await result.wait(1);
-    setState({ state: closeOnResolve ? "success" : "redirect", receipt });
+    setState({ state: "success", receipt });
   };
 
   const cancel = () => {
@@ -80,7 +73,7 @@ export function useTransactor({
   };
 
   useEffect(() => {
-    if (state.state !== "success" && state.state !== "redirect") return;
+    if (state.state !== "success") return;
     onSuccess(state.receipt);
   }, [state, onSuccess]);
 


### PR DESCRIPTION
Adds an extra state of redirecting to show a "Transaction resolved! Redirecting..." step of the modal with a link to the polygonscan transaction. The step will cover for async resolution such as parsing the event logs and posting the new object into the database before redirecting, preventing missing data and weirdly long load times between the modal closing and the redirect.

The transactor now has a closeOnResolve param which defaults to the original behavior of true. For any post-transaction callbacks in onSuccess, use closeOnResolve as false to hide the loading time.

Slight styling is probably still needed and although I haven't noticed any so far, if any processing in the onSuccess is super quick then the jumpiness might look weird.