### PR TITLE
fix: remove LM creator perm bypass

### DIFF
--- a/app/features/labor-market-creator/labor-market-creator.tsx
+++ b/app/features/labor-market-creator/labor-market-creator.tsx
@@ -122,17 +122,17 @@ function configureFromValues(
 
   const nodes = [
     {
-      deployerAllowed: true,
+      deployerAllowed: false,
       required: BigNumber.from(inputs.values.sponsor.numberBadgesRequired || 1),
       badges: sponsorBadges,
     },
     {
-      deployerAllowed: true,
+      deployerAllowed: false,
       required: BigNumber.from(inputs.values.analyst.numberBadgesRequired || 1),
       badges: analystBadges,
     },
     {
-      deployerAllowed: true,
+      deployerAllowed: false,
       required: BigNumber.from(inputs.values.reviewer.numberBadgesRequired || 1),
       badges: reviewerBadges,
     },


### PR DESCRIPTION
Default setting to not allow a LM creator to bypass the N-badge permissioning system for request, submission, and review creation.