### PR TITLE
fix: participation id is not unique

### DIFF
--- a/app/domain/reward-submissions/synchronize.server.ts
+++ b/app/domain/reward-submissions/synchronize.server.ts
@@ -8,6 +8,7 @@ import type { FetchClaimsResponse, FetchSignaturesResponse } from "../treasury";
 import { fetchSignaturesBodySchema } from "../treasury";
 import { BucketEnforcement__factory } from "~/contracts";
 import { nodeProvider } from "~/services/node.server";
+import { getSubmissionParticipationId } from "~/utils/helpers";
 
 const updateTreasuryData = async (submissions: SubmissionWithServiceRequest[]) => {
   const iouSubmissions = submissions.filter((s) => s.reward?.isIou === true && !s.reward?.iouHasRedeemed);
@@ -17,7 +18,7 @@ const updateTreasuryData = async (submissions: SubmissionWithServiceRequest[]) =
   const fetchSignaturesBody = iouSubmissions.map((s) => {
     invariant(s.reward?.tokenAmount, `submission ${s.id} has no tokenAmount`);
     return {
-      participationID: s.id,
+      participationID: getSubmissionParticipationId(s),
       claimerAddress: s.configuration.fulfiller,
       marketplaceAddress: s.laborMarketAddress,
       iouAddress: s.sr.configuration.pTokenProvider,
@@ -31,7 +32,7 @@ const updateTreasuryData = async (submissions: SubmissionWithServiceRequest[]) =
     iouSubmissions.map((s) => {
       return {
         marketplaceAddress: s.laborMarketAddress,
-        participationId: s.id,
+        participationId: getSubmissionParticipationId(s),
         type: "submission",
       };
     })
@@ -66,7 +67,7 @@ const getSignature = (signatures: FetchSignaturesResponse, submission: Submissio
   return signatures.find(
     (c) =>
       c.signedBody.marketplaceAddress === submission.laborMarketAddress &&
-      c.signedBody.participationID === submission.id
+      c.signedBody.participationID === getSubmissionParticipationId(submission)
   );
 };
 
@@ -75,7 +76,7 @@ const hasRedeemed = (claims: FetchClaimsResponse[], submission: SubmissionDoc) =
     return c.claims.val.find(
       (v) =>
         v.marketplaceAddress === submission.laborMarketAddress &&
-        v.participationID === submission.id &&
+        v.participationID === getSubmissionParticipationId(submission) &&
         v.redeemTx !== null
     );
   });

--- a/app/features/reward-review-creator/reward-review-iou-creator.tsx
+++ b/app/features/reward-review-creator/reward-review-iou-creator.tsx
@@ -11,6 +11,7 @@ import ConnectWalletWrapper from "../connect-wallet-wrapper";
 import { NoPayoutAddressFoundModalButton } from "../my-rewards/no-payout-address-modal-button";
 import { RedeemConfirmation } from "../my-rewards/redeem-confirmation";
 import { iouTokenAbi } from "~/abi/iou-token";
+import { getReviewParticipationId } from "~/utils/helpers";
 
 interface RedeemRewardCreatorProps {
   review: ReviewDoc;
@@ -49,7 +50,7 @@ export function RewardReviewIOUCreator({ review }: RedeemRewardCreatorProps) {
           inputs: {
             iouTokenAddress: token.contractAddress as EvmAddress,
             laborMarketAddress: review.laborMarketAddress,
-            submissionId: review.id, //TODO what should this be
+            participationId: getReviewParticipationId(review),
             amount: review.reward.tokenAmount,
             signature: signature as `0x${string}`,
           },
@@ -105,16 +106,16 @@ function configureRedeem({
   inputs: {
     iouTokenAddress: EvmAddress;
     laborMarketAddress: EvmAddress;
-    submissionId: string;
+    participationId: string;
     amount: string;
     signature: `0x${string}`;
   };
 }) {
-  const { iouTokenAddress, laborMarketAddress, submissionId, amount, signature } = inputs;
+  const { iouTokenAddress, laborMarketAddress, participationId, amount, signature } = inputs;
   return configureWrite({
     address: iouTokenAddress,
     abi: iouTokenAbi,
     functionName: "redeem",
-    args: [laborMarketAddress, BigNumber.from(submissionId), "review", BigNumber.from(amount), signature],
+    args: [laborMarketAddress, BigNumber.from(participationId), "review", BigNumber.from(amount), signature],
   });
 }

--- a/app/features/reward-submission-creator/reward-submission-iou-creator.tsx
+++ b/app/features/reward-submission-creator/reward-submission-iou-creator.tsx
@@ -11,6 +11,7 @@ import ConnectWalletWrapper from "../connect-wallet-wrapper";
 import { NoPayoutAddressFoundModalButton } from "../my-rewards/no-payout-address-modal-button";
 import { RedeemConfirmation } from "../my-rewards/redeem-confirmation";
 import { iouTokenAbi } from "~/abi/iou-token";
+import { getSubmissionParticipationId } from "~/utils/helpers";
 
 interface RedeemRewardCreatorProps {
   submission: SubmissionWithReward;
@@ -48,7 +49,7 @@ export function SubmissionIOURewardCreator({ submission }: RedeemRewardCreatorPr
           inputs: {
             iouTokenAddress: token.contractAddress as EvmAddress,
             laborMarketAddress: submission.laborMarketAddress,
-            submissionId: submission.id,
+            participationId: getSubmissionParticipationId(submission),
             amount: submission.reward.tokenAmount,
             signature: signature as `0x${string}`,
           },
@@ -162,16 +163,16 @@ function configureRedeem({
   inputs: {
     iouTokenAddress: EvmAddress;
     laborMarketAddress: EvmAddress;
-    submissionId: string;
+    participationId: string;
     amount: string;
     signature: `0x${string}`;
   };
 }) {
-  const { iouTokenAddress, laborMarketAddress, submissionId, amount, signature } = inputs;
+  const { iouTokenAddress, laborMarketAddress, participationId, amount, signature } = inputs;
   return configureWrite({
     address: iouTokenAddress,
     abi: iouTokenAbi,
     functionName: "redeem",
-    args: [laborMarketAddress, BigNumber.from(submissionId), "submission", BigNumber.from(amount), signature],
+    args: [laborMarketAddress, BigNumber.from(participationId), "submission", BigNumber.from(amount), signature],
   });
 }

--- a/app/utils/helpers.test.ts
+++ b/app/utils/helpers.test.ts
@@ -1,4 +1,5 @@
-import { fromTokenAmount } from "./helpers";
+import { ethers } from "ethers";
+import { fromTokenAmount, hashToUint256 } from "./helpers";
 
 describe("fromTokenAmount rounding", () => {
   test("numbers greater than or equal to 1", () => {
@@ -16,5 +17,17 @@ describe("fromTokenAmount rounding", () => {
     expect(result).toBe("0.0003556");
     result = fromTokenAmount("12555", 18, 2);
     expect(result).toBe("0.000000000000013");
+  });
+});
+
+describe("Participation id hashing", () => {
+  test("review document", () => {
+    const review = {
+      serviceRequestId: "2468098975717564244596535739996048250590380252504592812668",
+      submissionId: "309131532810312892982854808926614953617330872896",
+      id: "979952040593592027018162751923477643798263213460",
+    };
+    const bn = hashToUint256(`${review.serviceRequestId}${review.submissionId}${review.id}`);
+    expect(bn.lte(ethers.constants.MaxUint256)).toBe(true);
   });
 });

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -2,6 +2,9 @@ import type { Project, Token } from "@prisma/client";
 import { BigNumber, ethers } from "ethers";
 import type { ServiceRequestDoc } from "~/domain/service-request/schemas";
 import { claimDate } from "./date";
+import type { ReviewDoc } from "~/domain";
+import type { SubmissionDoc } from "~/domain/submission/schemas";
+import invariant from "tiny-invariant";
 
 export const truncateAddress = (address: string) => {
   if (address.length < 10) {
@@ -122,3 +125,22 @@ export function getEventFromLogs(
     .map((log) => iface.parseLog(log))
     .find((e) => e.name === eventName);
 }
+
+// review id is not enough for uniqueness. Need to also look at serviceRequestId and submissionId
+export const getReviewParticipationId = (r: ReviewDoc) => {
+  const id = ethers.utils.id(`${r.serviceRequestId}${r.submissionId}${r.id}`);
+  return hashToUint256(id).toString();
+};
+
+// submission id is not enough for uniqueness. Need to also look at serviceRequestId
+export const getSubmissionParticipationId = (s: SubmissionDoc) => {
+  const id = `${s.serviceRequestId}${s.id}`;
+  return hashToUint256(id).toString();
+};
+
+export const hashToUint256 = (text: string) => {
+  const hash = ethers.utils.id(text);
+  const bn = BigNumber.from(hash);
+  invariant(bn.lte(ethers.constants.MaxUint256), "Hash is too large to fit in a BigNumber"); // just in case
+  return bn;
+};

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -128,7 +128,7 @@ export function getEventFromLogs(
 
 // review id is not enough for uniqueness. Need to also look at serviceRequestId and submissionId
 export const getReviewParticipationId = (r: ReviewDoc) => {
-  const id = ethers.utils.id(`${r.serviceRequestId}${r.submissionId}${r.id}`);
+  const id = `${r.serviceRequestId}${r.submissionId}${r.id}`;
   return hashToUint256(id).toString();
 };
 


### PR DESCRIPTION
Problem:
Participation Id needs to be unique. Currently it is just the submission id or the review id, neither of which is unique by itself. For a submission a unique identifier is { laborMarketAddress, serviceRequestId, submissionId } and for a review it is { laborMarketAddress, serviceRequestId, submissionId, reviewId }.

Solution:
A concatenation of the ids would result in a value that is too large for the `uint256` type requirement of the IOU contract ([See](https://github.com/FlipsideCrypto/iou/blob/master/contracts/IOU.sol#L139)). The `ethers.utils.id` function is therefore used which does a KECCAK256 hash of the concatenated id string. This should result in a unique hash number that can be used as a participation id and does not overflow the uint256 type requirement.